### PR TITLE
Fix statusbar update

### DIFF
--- a/client/components/Controller/MainView.js
+++ b/client/components/Controller/MainView.js
@@ -9,7 +9,12 @@ import {PlayerHand} from './PlayerHand'
 import {addInfection} from '../../funcs/utils'
 import {Rules} from './Rules'
 import CURRENT_GAME from '../../../secrets'
-import {shuffle, addEpidemics} from '../../funcs/utils' //updateActions
+import {
+  shuffle,
+  addEpidemics,
+  resetDidOutbreak,
+  updateBoardStatus
+} from '../../funcs/utils' //updateActions
 import OutbreakTracker from '../OutbreakTracker'
 import {TreatView} from './TreatView'
 import {Modal, Button} from 'semantic-ui-react'
@@ -440,6 +445,9 @@ class MainView extends Component {
       await this.drawPlayerCard()
       await this.drawInfectionCard()
       await this.drawInfectionCard()
+
+      await resetDidOutbreak()
+      await updateBoardStatus()
     }
   }
 
@@ -524,7 +532,21 @@ class MainView extends Component {
   render() {
     return (
       <div>
-        {/* <button onClick={() => { this.executeEpidemic() }}>executeEpidemic</button> */}
+        <button
+          onClick={() => {
+            this.executeEpidemic()
+          }}
+        >
+          executeEpidemic
+        </button>
+        <button
+          onClick={() => {
+            updateBoardStatus()
+          }}
+        >
+          updateBoardStatus
+        </button>
+
         {this.state.showRules ? (
           <Rules
             show={this.show}

--- a/client/components/Controller/MainView.js
+++ b/client/components/Controller/MainView.js
@@ -9,7 +9,7 @@ import {PlayerHand} from './PlayerHand'
 import {addInfection} from '../../funcs/utils'
 import {Rules} from './Rules'
 import CURRENT_GAME from '../../../secrets'
-import {shuffle, addEpidemics} from '../../funcs/utils'
+import {shuffle, addEpidemics, updateActions} from '../../funcs/utils'
 import OutbreakTracker from '../OutbreakTracker'
 import {TreatView} from './TreatView'
 import {Modal, Button} from 'semantic-ui-react'
@@ -122,7 +122,8 @@ class MainView extends Component {
       },
       {merge: true}
     )
-    this.turnShouldChange(this.state.playerInfo, `${this.state.playerId}`)
+    // this.turnShouldChange(this.state.playerInfo, `${this.state.playerId}`)
+    updateActions(this.state.playerInfo)
   }
 
   buildResearchStation = async city => {
@@ -156,7 +157,8 @@ class MainView extends Component {
         {merge: true}
       )
     }
-    this.turnShouldChange(this.state.playerInfo, `${this.state.playerId}`)
+    // this.turnShouldChange(this.state.playerInfo, `${this.state.playerId}`)
+    updateActions(this.state.playerInfo)
   }
 
   drawPlayerCard = async () => {
@@ -545,7 +547,8 @@ class MainView extends Component {
               infectionStatus={this.state.infectionStatus}
               playerInfo={this.state.playerInfo}
               playerId={this.state.playerId}
-              nextTurn={this.turnShouldChange}
+              // nextTurn={this.turnShouldChange}
+              nextTurn={updateActions}
             />
           )}
           {this.state.currentView === 'special' && (

--- a/client/components/Controller/MainView.js
+++ b/client/components/Controller/MainView.js
@@ -116,14 +116,14 @@ class MainView extends Component {
     await this.game.set(
       {
         [`${this.playerId}Info`]: {
-          location: city,
-          actions: this.state.playerInfo.actions - 1
+          location: city
+          // actions: this.state.playerInfo.actions - 1
         }
       },
       {merge: true}
     )
     // this.turnShouldChange(this.state.playerInfo, `${this.state.playerId}`)
-    updateActions(this.state.playerInfo)
+    updateActions(`${this.playerId}Info`)
   }
 
   buildResearchStation = async city => {
@@ -158,7 +158,7 @@ class MainView extends Component {
       )
     }
     // this.turnShouldChange(this.state.playerInfo, `${this.state.playerId}`)
-    updateActions(this.state.playerInfo)
+    updateActions(`${this.playerId}Info`)
   }
 
   drawPlayerCard = async () => {
@@ -447,7 +447,6 @@ class MainView extends Component {
         cities,
         turnCounter
       })
-      console.log(this.state)
     })
   }
 
@@ -548,7 +547,6 @@ class MainView extends Component {
               playerInfo={this.state.playerInfo}
               playerId={this.state.playerId}
               // nextTurn={this.turnShouldChange}
-              nextTurn={updateActions}
             />
           )}
           {this.state.currentView === 'special' && (

--- a/client/components/Controller/TreatView.js
+++ b/client/components/Controller/TreatView.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/button-has-type */
 import React from 'react'
 import {treatInfection} from '../../funcs/utils'
 import db from '../../../server/db'
@@ -32,7 +33,8 @@ export const TreatView = props => {
             props.infectionStatus
           )
           decrementActions(props.playerId, props.playerInfo.actions)
-          props.nextTurn(props.playerInfo, `${props.playerId}`)
+          // props.nextTurn(props.playerInfo, `${props.playerId}`)
+          props.nextTurn(props.playerInfo)
         }}
       >
         TREAT
@@ -53,7 +55,8 @@ export const TreatView = props => {
             props.infectionStatus
           )
           decrementActions(props.playerId, props.playerInfo.actions)
-          props.nextTurn(props.playerInfo, `${props.playerId}`)
+          // props.nextTurn(props.playerInfo, `${props.playerId}`)
+          props.nextTurn(props.playerInfo)
         }}
       >
         TREAT
@@ -74,7 +77,8 @@ export const TreatView = props => {
             props.infectionStatus
           )
           decrementActions(props.playerId, props.playerInfo.actions)
-          props.nextTurn(props.playerInfo, `${props.playerId}`)
+          // props.nextTurn(props.playerInfo, `${props.playerId}`)
+          props.nextTurn(props.playerInfo)
         }}
       >
         TREAT
@@ -95,7 +99,8 @@ export const TreatView = props => {
             props.infectionStatus
           )
           decrementActions(props.playerId, props.playerInfo.actions)
-          props.nextTurn(props.playerInfo, `${props.playerId}`)
+          // props.nextTurn(props.playerInfo, `${props.playerId}`)
+          props.nextTurn(props.playerInfo)
         }}
       >
         TREAT

--- a/client/components/Controller/TreatView.js
+++ b/client/components/Controller/TreatView.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/button-has-type */
 import React from 'react'
-import {treatInfection} from '../../funcs/utils'
+import {treatInfection, updateActions} from '../../funcs/utils'
 import db from '../../../server/db'
 import CURRENT_GAME from '../../../secrets'
 
@@ -32,9 +32,9 @@ export const TreatView = props => {
             props.playerCityInfo.diseases,
             props.infectionStatus
           )
-          decrementActions(props.playerId, props.playerInfo.actions)
+          // decrementActions(props.playerId, props.playerInfo.actions)
           // props.nextTurn(props.playerInfo, `${props.playerId}`)
-          props.nextTurn(props.playerInfo)
+          updateActions(props.playerId)
         }}
       >
         TREAT
@@ -54,9 +54,9 @@ export const TreatView = props => {
             props.playerCityInfo.diseases,
             props.infectionStatus
           )
-          decrementActions(props.playerId, props.playerInfo.actions)
+          // decrementActions(props.playerId, props.playerInfo.actions)
           // props.nextTurn(props.playerInfo, `${props.playerId}`)
-          props.nextTurn(props.playerInfo)
+          updateActions(props.playerId)
         }}
       >
         TREAT
@@ -76,9 +76,9 @@ export const TreatView = props => {
             props.playerCityInfo.diseases,
             props.infectionStatus
           )
-          decrementActions(props.playerId, props.playerInfo.actions)
+          // decrementActions(props.playerId, props.playerInfo.actions)
           // props.nextTurn(props.playerInfo, `${props.playerId}`)
-          props.nextTurn(props.playerInfo)
+          updateActions(props.playerId)
         }}
       >
         TREAT
@@ -98,9 +98,9 @@ export const TreatView = props => {
             props.playerCityInfo.diseases,
             props.infectionStatus
           )
-          decrementActions(props.playerId, props.playerInfo.actions)
+          // decrementActions(props.playerId, props.playerInfo.actions)
           // props.nextTurn(props.playerInfo, `${props.playerId}`)
-          props.nextTurn(props.playerInfo)
+          updateActions(props.playerId)
         }}
       >
         TREAT

--- a/client/components/Controller/TreatView.js
+++ b/client/components/Controller/TreatView.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/button-has-type */
 import React from 'react'
-import {treatInfection, updateActions} from '../../funcs/utils'
+import {treatInfection} from '../../funcs/utils' //, updateActions
 import db from '../../../server/db'
 import CURRENT_GAME from '../../../secrets'
 
@@ -34,7 +34,7 @@ export const TreatView = props => {
           )
           // decrementActions(props.playerId, props.playerInfo.actions)
           // props.nextTurn(props.playerInfo, `${props.playerId}`)
-          updateActions(props.playerId)
+          props.updateActions(props.playerId)
         }}
       >
         TREAT
@@ -56,7 +56,7 @@ export const TreatView = props => {
           )
           // decrementActions(props.playerId, props.playerInfo.actions)
           // props.nextTurn(props.playerInfo, `${props.playerId}`)
-          updateActions(props.playerId)
+          props.updateActions(props.playerId)
         }}
       >
         TREAT
@@ -78,7 +78,7 @@ export const TreatView = props => {
           )
           // decrementActions(props.playerId, props.playerInfo.actions)
           // props.nextTurn(props.playerInfo, `${props.playerId}`)
-          updateActions(props.playerId)
+          props.updateActions(props.playerId)
         }}
       >
         TREAT
@@ -100,7 +100,7 @@ export const TreatView = props => {
           )
           // decrementActions(props.playerId, props.playerInfo.actions)
           // props.nextTurn(props.playerInfo, `${props.playerId}`)
-          updateActions(props.playerId)
+          props.updateActions(props.playerId)
         }}
       >
         TREAT

--- a/client/components/Controller/airplaneMoves.js
+++ b/client/components/Controller/airplaneMoves.js
@@ -2,7 +2,6 @@ import React from 'react'
 import {discardPlayerCard} from '../../funcs/utils'
 
 export const AirplaneMoves = props => {
-  console.log(props, 'UPDATETETETTE')
   return (
     <button
       disabled={props.restrict}

--- a/client/funcs/utils.js
+++ b/client/funcs/utils.js
@@ -317,6 +317,36 @@ const researchCure = async (playerId, hand, playerDiscard, infectionStatus) => {
 //   }
 // }
 
+const updateBoardStatus = async () => {
+  const docRef = await game.get()
+  const data = await docRef.data()
+  const cities = data.cities
+  const infectionStatus = data.infectionStatus
+
+  infectionStatus.blue.count = 0
+  infectionStatus.yellow.count = 0
+  infectionStatus.black.count = 0
+  infectionStatus.red.count = 0
+
+  Object.keys(cities).forEach(city => {
+    infectionStatus.blue.count =
+      infectionStatus.blue.count + cities[city].diseases[0]
+    infectionStatus.yellow.count =
+      infectionStatus.yellow.count + cities[city].diseases[1]
+    infectionStatus.black.count =
+      infectionStatus.black.count + cities[city].diseases[2]
+    infectionStatus.red.count =
+      infectionStatus.red.count + cities[city].diseases[3]
+  })
+
+  await game.set(
+    {
+      infectionStatus
+    },
+    {merge: true}
+  )
+}
+
 module.exports = {
   shuffle,
   generateGroups,
@@ -326,6 +356,7 @@ module.exports = {
   discardPlayerCard,
   addEpidemics,
   researchCure,
-  resetDidOutbreak
+  resetDidOutbreak,
   // updateActions
+  updateBoardStatus
 }

--- a/client/funcs/utils.js
+++ b/client/funcs/utils.js
@@ -263,6 +263,46 @@ const researchCure = async (playerId, hand, playerDiscard, infectionStatus) => {
   }
 }
 
+const updateActions = async player => {
+  const docRef = await game.get()
+  const data = await docRef.data()
+
+  const whoIsNext = {
+    player1Info: 'player2Info',
+    player2Info: 'player3Info',
+    player3Info: 'player4Info',
+    player4Info: 'player1Info'
+  }
+
+  const currentPlayerInfo = data[player]
+  const nextPlayer = whoIsNext[player]
+  const nextPlayerInfo = data[nextPlayer]
+
+  if (currentPlayerInfo.actions > 1 && currentPlayerInfo.isTurn === true) {
+    currentPlayerInfo.actions--
+    await game.set(
+      {
+        [player]: currentPlayerInfo
+      },
+      {merge: true}
+    )
+  }
+  if (currentPlayerInfo.actions <= 1) {
+    currentPlayerInfo.actions = 0
+    currentPlayerInfo.isTurn = false
+    nextPlayerInfo.actions = 4
+    nextPlayerInfo.isTurn = true
+
+    await game.set(
+      {
+        [player]: currentPlayerInfo,
+        [nextPlayer]: nextPlayerInfo
+      },
+      {merge: true}
+    )
+  }
+}
+
 module.exports = {
   shuffle,
   generateGroups,
@@ -272,5 +312,6 @@ module.exports = {
   discardPlayerCard,
   addEpidemics,
   researchCure,
-  resetDidOutbreak
+  resetDidOutbreak,
+  updateActions
 }

--- a/client/funcs/utils.js
+++ b/client/funcs/utils.js
@@ -280,19 +280,28 @@ const updateActions = async player => {
 
   if (currentPlayerInfo.actions > 1 && currentPlayerInfo.isTurn === true) {
     currentPlayerInfo.actions--
+    console.log('actions > 1, decrement only', player, currentPlayerInfo)
     await game.set(
       {
         [player]: currentPlayerInfo
       },
       {merge: true}
     )
-  }
-  if (currentPlayerInfo.actions <= 1) {
+  } else if (
+    currentPlayerInfo.actions <= 1 &&
+    currentPlayerInfo.isTurn === true
+  ) {
     currentPlayerInfo.actions = 0
     currentPlayerInfo.isTurn = false
     nextPlayerInfo.actions = 4
     nextPlayerInfo.isTurn = true
-
+    console.log(
+      'actions = 1, set to 0 and switch players',
+      player,
+      currentPlayerInfo,
+      nextPlayer,
+      nextPlayerInfo
+    )
     await game.set(
       {
         [player]: currentPlayerInfo,

--- a/client/funcs/utils.js
+++ b/client/funcs/utils.js
@@ -3,6 +3,12 @@
 const infectionDeck = require('../data/infectionDeck')
 const db = require('../../server/db')
 const CURRENT_GAME = require('../../secrets')
+// import MainView from '../components/Controller/MainView'
+
+// const Player1MainView = new MainView()
+// const Player2MainView = new MainView()
+// const Player3MainView = new MainView()
+// const Player4MainView = new MainView()
 
 const game = db.collection('rooms').doc(CURRENT_GAME)
 
@@ -263,54 +269,53 @@ const researchCure = async (playerId, hand, playerDiscard, infectionStatus) => {
   }
 }
 
-const updateActions = async player => {
-  const docRef = await game.get()
-  const data = await docRef.data()
+// const updateActions = async player => {
+//   const docRef = await game.get()
+//   const data = await docRef.data()
 
-  const whoIsNext = {
-    player1Info: 'player2Info',
-    player2Info: 'player3Info',
-    player3Info: 'player4Info',
-    player4Info: 'player1Info'
-  }
+//   const whoIsNext = {
+//     player1Info: 'player2Info',
+//     player2Info: 'player3Info',
+//     player3Info: 'player4Info',
+//     player4Info: 'player1Info'
+//   }
 
-  const currentPlayerInfo = data[player]
-  const nextPlayer = whoIsNext[player]
-  const nextPlayerInfo = data[nextPlayer]
+//   const currentPlayerInfo = data[player]
+//   const nextPlayer = whoIsNext[player]
+//   const nextPlayerInfo = data[nextPlayer]
 
-  if (currentPlayerInfo.actions > 1 && currentPlayerInfo.isTurn === true) {
-    currentPlayerInfo.actions--
-    console.log('actions > 1, decrement only', player, currentPlayerInfo)
-    await game.set(
-      {
-        [player]: currentPlayerInfo
-      },
-      {merge: true}
-    )
-  } else if (
-    currentPlayerInfo.actions <= 1 &&
-    currentPlayerInfo.isTurn === true
-  ) {
-    currentPlayerInfo.actions = 0
-    currentPlayerInfo.isTurn = false
-    nextPlayerInfo.actions = 4
-    nextPlayerInfo.isTurn = true
-    console.log(
-      'actions = 1, set to 0 and switch players',
-      player,
-      currentPlayerInfo,
-      nextPlayer,
-      nextPlayerInfo
-    )
-    await game.set(
-      {
-        [player]: currentPlayerInfo,
-        [nextPlayer]: nextPlayerInfo
-      },
-      {merge: true}
-    )
-  }
-}
+//   if (currentPlayerInfo.actions > 1 && currentPlayerInfo.isTurn === true) {
+//     currentPlayerInfo.actions--
+//     console.log('actions > 1, decrement only', player, currentPlayerInfo)
+//     await game.set(
+//       {
+//         [player]: currentPlayerInfo
+//       },
+//       { merge: true }
+//     )
+//   } else if (
+//     currentPlayerInfo.actions <= 1 &&
+//     currentPlayerInfo.isTurn === true
+//   ) {
+//     currentPlayerInfo.actions = 0
+//     currentPlayerInfo.isTurn = false
+//     nextPlayerInfo.actions = 4
+//     nextPlayerInfo.isTurn = true
+
+//     await game.set(
+//       {
+//         [player]: currentPlayerInfo,
+//         [nextPlayer]: nextPlayerInfo
+//       },
+//       { merge: true }
+//     )
+
+//     await this.drawInfectionCard()
+//     await this.drawInfectionCard()
+//     await this.drawPlayerCard()
+//     await this.drawPlayerCard()
+//   }
+// }
 
 module.exports = {
   shuffle,
@@ -321,6 +326,6 @@ module.exports = {
   discardPlayerCard,
   addEpidemics,
   researchCure,
-  resetDidOutbreak,
-  updateActions
+  resetDidOutbreak
+  // updateActions
 }

--- a/script/seedFirebase.js
+++ b/script/seedFirebase.js
@@ -14,7 +14,11 @@ const {
   player4Info
 } = require('../client/data/playerInfo')
 const CURRENT_GAME = require('../secrets')
-const {shuffle, addEpidemics} = require('../client/funcs/utils')
+const {
+  shuffle,
+  addEpidemics,
+  updateBoardStatus
+} = require('../client/funcs/utils')
 
 const infectionIdx = 0
 const infectionRate = [2, 2, 2, 3, 3, 4, 4]
@@ -118,3 +122,4 @@ async function runSeed() {
 }
 
 runSeed()
+updateBoardStatus()


### PR DESCRIPTION
This branch has my implementation of turn order tracking.
At the end of each turn, player and infection cards are drawn.
Infection cards infect cities, and triggers outbreaks if it should.
Epidemic cards, when drawn, will infect and outbreak if it should. Also shuffles the discards back on top of the deck.
Status bar updates after running seed-firestore, and again when player turn changes.
Each city's didOutbreak boolean resets to false when player turn changes.